### PR TITLE
Modificar a variável "taxa" de int para float

### DIFF
--- a/modules/gateways/paghiper.php
+++ b/modules/gateways/paghiper.php
@@ -121,7 +121,7 @@
                 $invoiceid = checkCbInvoiceID($_POST['idPlataforma'], $GATEWAY["name"]);
                 checkCbTransID($_POST['idPlataforma']);
                 $valor = (float)$valorTotal - $valorOriginal;
-                $taxa = (int) $GATEWAY['taxa'];
+                $taxa = (float) $GATEWAY['taxa'];
                 addInvoicePayment($invoiceid, $_POST['idPlataforma'], $valor, $taxa, 'paghiper');
             }
         }


### PR DESCRIPTION
Com a implementação em "int" a taxa apenas assume valores inteiros, o que faz com que o calculo de taxas no WHMCS fique errado para valores não inteiros. Mudar para float resolverá esse problema.