### PR TITLE
Gerar boleto apenas quando solicitado

### DIFF
--- a/modules/gateways/paghiper.php
+++ b/modules/gateways/paghiper.php
@@ -121,28 +121,12 @@
                 $invoiceid = checkCbInvoiceID($_POST['idPlataforma'], $GATEWAY["name"]);
                 checkCbTransID($_POST['idPlataforma']);
                 $valor = (float)$valorTotal - $valorOriginal;
-                $taxa = (int) $GATEWAY['taxa'];
+                $taxa = (float) $GATEWAY['taxa'];
                 addInvoicePayment($invoiceid, $_POST['idPlataforma'], $valor, $taxa, 'paghiper');
             }
         }
     }
 
-    function httpPost($url,$params)
-    {
-        $postData = '';
-        foreach($params as $k => $v) { $postData .= $k . '='.$v.'&'; }
-        $postData = rtrim($postData, '&');
-        $ch = curl_init();   
-        curl_setopt($ch,CURLOPT_URL,$url);
-        curl_setopt($ch,CURLOPT_RETURNTRANSFER,true);
-        curl_setopt($ch,CURLOPT_HEADER, false); 
-        curl_setopt($ch, CURLOPT_POST, count($postData));
-        curl_setopt($ch, CURLOPT_POSTFIELDS, $postData);
-        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true); 
-        $output=curl_exec($ch); 
-        curl_close($ch);
-        return $output; 
-    }
     function get_tag( $attr, $value, $xml ) {
 
         $attr = preg_quote($attr);
@@ -244,13 +228,13 @@
            "nome" => $params['clientdetails']['firstname'].' '.$params['clientdetails']['lastname'], 
            "pagamento" => "pagamento"
         );
-
-        $boleto = httpPost("https://www.paghiper.com/checkout/",$paramsboleto);
-
+		
+		$_SESSION['parametros'] = $paramsboleto;
+		
         $linha1 = get_tag('id', 'DadosBoleto', $boleto);
         $kl1 = strpos($linha1, "{");
         $kl2 = (int)strpos($linha1, "}") - (int)$kl1 + 1;
         $dadosboleto = json_decode(substr($linha1,$kl1,$kl2));
-        return ($params['linha']=="1"?'<div class="form-group"><label><i class="fa fa-keyboard-o"></i> Linha digitável</label><input type="text" id="linha" onfocus="this.select();" onmouseup="return false;" readonly="true" value="'.$dadosboleto->linhaDigitavel.'" class="form-control"></div>':null)."<span onclick='abrirboleto()' class='btn btn-block btn-primary'>".$params['botaopagar']."</span><div class='hidden' id='boleto'>".$boleto."</div><script src='https://code.jquery.com/jquery-1.12.4.min.js'integrity='sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ='crossorigin='anonymous'></script><script src='https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js' integrity='sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS' crossorigin='anonymous'></script><script>function abrirboleto(){var w = window.open('', '', 'width=800, height=500, scrollbars=yes');var html = $('#boleto').html(); $(w.document.body).html(html);}".($params['abrirauto']==true ? "\$(document).ready(function() {\$('body').html(\$('#boleto').html());});" : null ).'</script>';
-    }
+         return ($params['linha']=="1"?'<div class="form-group"><label><i class="fa fa-keyboard-o"></i> Linha digitável</label><input type="text" id="linha" onfocus="this.select();" onmouseup="return false;" readonly="true" value="'.$dadosboleto->linhaDigitavel.'" class="form-control"></div>':null)."<span onclick='abrirboleto()' class='btn btn-block btn-primary'>".$params['botaopagar']."</span><div class='hidden' id='boleto'>".$boleto."</div><script src='https://code.jquery.com/jquery-1.12.4.min.js'integrity='sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ='crossorigin='anonymous'></script><script src='https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js' integrity='sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS' crossorigin='anonymous'></script><script>function abrirboleto(){var w = window.open('/modules/gateways/paghiper/mostraboleto.php', '', 'width=800, height=500, scrollbars=yes');}".($params['abrirauto']==true ? "\$(document).ready(function() {\$('body').html(\$('#boleto').html());});" : null ).'</script>';
+		 }
 ?>

--- a/modules/gateways/paghiper/index.php
+++ b/modules/gateways/paghiper/index.php
@@ -1,0 +1,2 @@
+<?php
+header("Location: ../index.php");

--- a/modules/gateways/paghiper/mostraboleto.php
+++ b/modules/gateways/paghiper/mostraboleto.php
@@ -1,0 +1,25 @@
+<?php
+require("../../../dbconnect.php");
+	$paramsboleto = $_SESSION['parametros'];
+		
+function httpPost($url,$params)
+    {
+        $postData = '';
+        foreach($params as $k => $v) { $postData .= $k . '='.$v.'&'; }
+        $postData = rtrim($postData, '&');
+        $ch = curl_init();   
+        curl_setopt($ch,CURLOPT_URL,$url);
+        curl_setopt($ch,CURLOPT_RETURNTRANSFER,true);
+        curl_setopt($ch,CURLOPT_HEADER, false); 
+        curl_setopt($ch, CURLOPT_POST, count($postData));
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $postData);
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true); 
+        $output=curl_exec($ch); 
+        curl_close($ch);
+        return $output; 
+    }
+
+$boleto = httpPost("https://www.paghiper.com/checkout/",$paramsboleto);
+
+echo $boleto;
+?>


### PR DESCRIPTION
Agora o boleto apenas é gerado em outra página, e quando o cliente solicita que seja gerado. Isso evita que seja gerado e mostrado (mesmo que hidden) um boleto apenas ao acessar a fatura através do WHMCS.

Para manter o módulo seguro e evitar que o cliente edite algum parâmetro, os dados do boleto estão sendo passados por sessões, que são server-side.