### PR TITLE
Mudar de dbconnect.php para init.php

### DIFF
--- a/modules/gateways/paghiper/mostraboleto.php
+++ b/modules/gateways/paghiper/mostraboleto.php
@@ -1,5 +1,5 @@
 <?php
-require("../../../dbconnect.php");
+require("../../../init.php");
 	$paramsboleto = $_SESSION['parametros'];
 		
 function httpPost($url,$params)


### PR DESCRIPTION
O arquivo dbconnect.php que estava sendo incluso antes não está presente no WHMCS por padrão, e as novas instalações usam o init.php